### PR TITLE
Timer unref option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+.idea
 
 pids
 logs

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Simple in-memory object cache with TTL based per-item expiry
 ## Options:
 
     var cache({
-            ttl: 300,       // Number of seconds to keep entries
-            interval: 60    // Cleaning interval
+            ttl: 300,           // Number of seconds to keep entries
+            interval: 60,       // Cleaning interval
+            unrefTimers: true   // Prevent timers blocking event loop (node only)
         });
 
 ## License:

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -19,6 +19,9 @@ function stop(cache) {
 function start(cache) {
 	if (cache.options.interval > 0) {
 		cache.timer = setTimeout(cache.clean, cache.options.interval * 1000);
+		if (cache.options.unrefTimers && cache.timer.unref) {
+			cache.timer.unref();
+		}
 	}
 }
 
@@ -56,12 +59,16 @@ function Cache(options) {
 	this.ttls = {};
 
 	this.options = {
-		ttl: 300,     // Default TTL 5 minutes.
-		interval: 60  // Clean every minute.
+		ttl: 300,     			// Default TTL 5 minutes.
+		interval: 60, 			// Clean every minute.
+		unrefTimers: false	// Call .unref() on timer objects
 	};
 
-	if (options && options.ttl) this.options.ttl = options.ttl;
-	if (options && options.interval) this.options.interval = options.interval;
+	if (options) {
+		if (options.ttl) this.options.ttl = options.ttl;
+		if (options.interval) this.options.interval = options.interval;
+		if (options.unrefTimers) this.options.unrefTimers = options.unrefTimers;
+	}
 
 	this.stats = {
 		hits: 0,


### PR DESCRIPTION
Add option to unref the TTL timer. Doing so will avoid a cache keeping a NodeJS process alive with its timer event handlers.